### PR TITLE
Add reproduction for IVF PQ metric_type overwrite on CPU

### DIFF
--- a/repros/ivfpq_metric_type_overwrite_cpu.py
+++ b/repros/ivfpq_metric_type_overwrite_cpu.py
@@ -1,0 +1,17 @@
+import numpy as np
+import faiss
+
+d = 32
+np.random.seed(0)
+xb = np.random.rand(2000, d).astype('float32')
+
+# Crea index con IVF+PQ
+index = faiss.index_factory(d, "IVF64,PQ16")
+
+# Imposta metric_type a INNER_PRODUCT (1)
+index.metric_type = faiss.METRIC_INNER_PRODUCT
+
+index.train(xb)
+index.add(xb)
+
+print("CPU metric_type =", index.metric_type)  # 1 = IP, 2 = L2


### PR DESCRIPTION
This PR adds a minimal reproduction script for the metric_type overwrite issue in IVF+PQ indexes on CPU.
The script:

Creates an IVF64,PQ16 index with metric_type set to METRIC_INNER_PRODUCT (1).
Trains and adds vectors.
Prints the metric_type after training and adding, showing it has been reset to METRIC_L2 (0).
Observed behavior:
After training and adding vectors, metric_type is reset to METRIC_L2 instead of keeping the user-defined METRIC_INNER_PRODUCT.
Expected behavior:
metric_type should remain METRIC_INNER_PRODUCT after training and adding vectors.